### PR TITLE
Fixed: missing step in install

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ Next, clone this repository into `$GOPATH/src/github.com/leonidlm/packer-builder
 
 ```
 cd $GOPATH/src/github.com/leonidlm/packer-builder-softlayer
+go get ./...
 go build -o /usr/local/packer/packer-builder-softlayer main.go
 ```
+
+Make sure mercurial is properly installed in your system and consequently `hg` binary is available on your path.
 
 Now [configure Packer](http://www.packer.io/docs/other/core-configuration.html) to pick up the new builder:
 


### PR DESCRIPTION
Fixed: missing instruction about installing go project dependencies before building the project. This step wouldn't be obvious for people who are not familiar with Go and just want to use this customer builder with Packer.
