### PR TITLE
use SL_ convention for env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ The reference of available configuration options is listed below.
 
 ### Required parameters:
 
- * `username` (string) - The user name to use to access your account. If unspecified, the value is taken from the SOFTLAYER_USER_NAME environment variable.
- * `api_key` (string) - The api key defined for the chosen user name. You can find what is your api key at the account->users tab of the SoftLayer web console. If unspecified, the value is taken from the SOFTLAYER_API_KEY environment variable.
+ * `username` (string) - The user name to use to access your account. If unspecified, the value is taken from the SL_USERNAME environment variable.
+ * `api_key` (string) - The api key defined for the chosen user name. You can find what is your api key at the account->users tab of the SoftLayer web console. If unspecified, the value is taken from the SL_API_KEY environment variable.
  * `image_name` (string) - The name of the resulting image that will appear in your account. This must be unique. To help make this unique, use a function like timestamp.
  * `base_image_id` (string) - The ID of the base image to use (usually defined by the `globalIdentifier` or the `uuid` fields in SoftLayer API). This is the image that will be used for launching a new instance. 
  __NOTE__ that if you choose to use this option, you must specify a private key using `ssh_private_key_file` (described below).

--- a/builder/softlayer/builder.go
+++ b/builder/softlayer/builder.go
@@ -77,12 +77,12 @@ func (self *Builder) Prepare(raws ...interface{}) (parms []string, retErr error)
 	// Assign default values if possible
 	if self.config.APIKey == "" {
 		// Default to environment variable for api_key, if it exists
-		self.config.APIKey = os.Getenv("SOFTLAYER_API_KEY")
+		self.config.APIKey = os.Getenv("SL_API_KEY")
 	}
 
 	if self.config.Username == "" {
 		// Default to environment variable for client_id, if it exists
-		self.config.Username = os.Getenv("SOFTLAYER_USER_NAME")
+		self.config.Username = os.Getenv("SL_USERNAME")
 	}
 
 	if self.config.DatacenterName == "" {
@@ -165,12 +165,12 @@ func (self *Builder) Prepare(raws ...interface{}) (parms []string, retErr error)
 	// Check for required configurations that will display errors if not set
 	if self.config.APIKey == "" {
 		errs = packer.MultiErrorAppend(
-			errs, errors.New("api_key or the SOFTLAYER_API_KEY environment variable must be specified"))
+			errs, errors.New("api_key or the SL_API_KEY environment variable must be specified"))
 	}
 
 	if self.config.Username == "" {
 		errs = packer.MultiErrorAppend(
-			errs, errors.New("username or the SOFTLAYER_USER_NAME environment variable must be specified"))
+			errs, errors.New("username or the SL_USERNAME environment variable must be specified"))
 	}
 
 	if self.config.ImageName == "" {


### PR DESCRIPTION
> You can pass in your username and api_key when creating a SoftLayer client instance. However, you can also set these in the environmental variables ‘SL_USERNAME’ and ‘SL_API_KEY’.

[ref](http://softlayer-python.readthedocs.org/en/latest/api/client.html#getting-started)

I didn't make it support the previous env names (`SOFTLAYER_*`) intentionally, since 1) having different combination of SL_ and SOFTLAYER_ env can be confusing and 2) this plugin is not the "official" one and I think it's okay to make that change.
